### PR TITLE
Add useScreenSize hook and make ProfileSidebar component responsive

### DIFF
--- a/src/features/UserProfile/ProfileSidebar/ProfileSidebar.tsx
+++ b/src/features/UserProfile/ProfileSidebar/ProfileSidebar.tsx
@@ -1,3 +1,4 @@
+import { useScreenSize } from '@features/hooks/useScreenSize';
 import { Menu, MenuProps } from 'antd';
 import Sider from 'antd/es/layout/Sider';
 import { useLocation, useNavigate } from 'react-router';
@@ -18,13 +19,22 @@ const items: MenuItem[] = [
 const ProfileSidebar = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { isMobile } = useScreenSize();
 
-  return (
+  return isMobile ? (
+    <Menu
+      items={items}
+      selectedKeys={[location.pathname]}
+      onSelect={(e) => navigate(e.key)}
+      mode={'horizontal'}
+    />
+  ) : (
     <Sider theme="light">
       <Menu
         items={items}
         selectedKeys={[location.pathname]}
         onSelect={(e) => navigate(e.key)}
+        mode={'vertical'}
       />
     </Sider>
   );

--- a/src/features/hooks/useScreenSize.tsx
+++ b/src/features/hooks/useScreenSize.tsx
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+
+export const useScreenSize = () => {
+  const [screenSize, setScreenSize] = useState({
+    width: window.innerWidth,
+    height: window.innerHeight,
+    isMobile: window.innerWidth < 768,
+    isTablet: window.innerWidth >= 768 && window.innerWidth < 1024,
+    isDesktop: window.innerWidth >= 1024,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+
+      setScreenSize({
+        width,
+        height,
+        isMobile: width < 768,
+        isTablet: width >= 768 && width < 1024,
+        isDesktop: width >= 1024,
+      });
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    // Cleanup
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return screenSize;
+};


### PR DESCRIPTION
Add useScreenSize hook and make ProfileSidebar component responsive

## 📸 Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/53338e13-d6f7-49e8-9c2c-5f11e8093cab)

## 🔍 Changes

- [x] Feature implemented / Bug fixed
- [ ] Tests added or updated
- [x] Linting and formatting run (`npm run lint` / `npm run format:fix`)
- [x] Manually tested locally
